### PR TITLE
Add camera zoom and autofocus with focus indicator

### DIFF
--- a/static/camera.js
+++ b/static/camera.js
@@ -1,0 +1,89 @@
+const ZOOM_STORAGE_KEY = 'globalCameraZoom';
+let video, track, zoomSlider, focusFrame;
+let focusCheckInterval;
+
+async function initCamera() {
+    video = document.getElementById('camera');
+    zoomSlider = document.getElementById('zoomSlider');
+    focusFrame = document.getElementById('focusFrame');
+
+    if (!video || !navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+        return;
+    }
+
+    try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+            video: { facingMode: { ideal: 'environment' } }
+        });
+        video.srcObject = stream;
+        track = stream.getVideoTracks()[0];
+        setupZoom();
+        triggerFocus();
+        focusCheckInterval = setInterval(checkFocus, 500);
+    } catch (err) {
+        console.error('Camera init failed', err);
+    }
+}
+
+function setupZoom() {
+    const capabilities = track.getCapabilities();
+    if (!capabilities.zoom) {
+        zoomSlider.style.display = 'none';
+        return;
+    }
+    const storedZoom = parseFloat(localStorage.getItem(ZOOM_STORAGE_KEY)) || capabilities.zoom.min || 1;
+    zoomSlider.min = capabilities.zoom.min || 1;
+    zoomSlider.max = capabilities.zoom.max || 3;
+    zoomSlider.step = capabilities.zoom.step || 0.1;
+    zoomSlider.value = storedZoom;
+    applyZoom(storedZoom);
+
+    zoomSlider.addEventListener('input', () => {
+        const val = parseFloat(zoomSlider.value);
+        applyZoom(val);
+        localStorage.setItem(ZOOM_STORAGE_KEY, val);
+        triggerFocus();
+    });
+}
+
+function applyZoom(val) {
+    track.applyConstraints({ advanced: [{ zoom: val }] }).catch(err => console.warn('Zoom not supported', err));
+}
+
+function triggerFocus() {
+    const capabilities = track.getCapabilities();
+    if (capabilities.focusMode && capabilities.focusMode.includes('continuous')) {
+        track.applyConstraints({ advanced: [{ focusMode: 'continuous' }] }).catch(()=>{});
+    } else if (capabilities.focusMode && capabilities.focusMode.includes('single-shot')) {
+        track.applyConstraints({ advanced: [{ focusMode: 'single-shot' }] }).catch(()=>{});
+    }
+}
+
+function checkFocus() {
+    if (!video || video.readyState < 2) return;
+    const canvas = document.createElement('canvas');
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+    const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+
+    // Laplacian variance focus measure
+    let sum = 0;
+    let sumSq = 0;
+    for (let i = 0; i < data.length; i += 4) {
+        const g = 0.299 * data[i] + 0.587 * data[i+1] + 0.114 * data[i+2];
+        sum += g;
+        sumSq += g * g;
+    }
+    const mean = sum / (data.length / 4);
+    const variance = sumSq / (data.length / 4) - mean * mean;
+    const threshold = 500;
+    if (variance > threshold) {
+        focusFrame.style.borderColor = 'lime';
+    } else {
+        focusFrame.style.borderColor = 'red';
+    }
+}
+
+document.addEventListener('DOMContentLoaded', initCamera);

--- a/static/style.css
+++ b/static/style.css
@@ -261,3 +261,29 @@ body.dark-mode .dark-mode-toggle i {
 body.dark-mode .language-toggle i {
     color: #e0e0e0;
 }
+
+/* Camera and focus styles */
+.camera-container {
+    position: relative;
+    width: 100%;
+    max-width: 400px;
+    margin: 10px auto;
+}
+#camera {
+    width: 100%;
+    border-radius: 10px;
+}
+#focusFrame {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: 4px solid red;
+    box-sizing: border-box;
+    pointer-events: none;
+}
+#zoomSlider {
+    width: 100%;
+    margin-top: 5px;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,6 +25,12 @@
         <!-- 输入框 -->
         <input type="text" id="barcodeInput" placeholder="扫码或手动输入条码" class="barcode-input" />
 
+        <div class="camera-container">
+            <video id="camera" autoplay playsinline></video>
+            <div id="focusFrame"></div>
+            <input type="range" id="zoomSlider" min="1" max="3" step="0.1">
+        </div>
+
         <!-- 提示 -->
         <p id="message" class="message"></p>
 
@@ -68,6 +74,7 @@
 
     <!-- 引入自定义脚本 -->
     <script src="{{ url_for('static', filename='script.js') }}"></script>
+    <script src="{{ url_for('static', filename='camera.js') }}"></script>
 
     <!-- Bootstrap JavaScript -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- add camera interface with manual zoom slider and focus frame
- persist zoom level globally and re-focus after zoom changes
- detect focus using variance-based algorithm and show red/green frame

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a695af902483339ad7e1b0dd7b47bb